### PR TITLE
trying but failing to get twitter auth associated with regular auth

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -25,9 +25,15 @@ class SessionsController < ApplicationController
   end
 
   def twitter
-    # raise request.env["omniauth.auth"].to_yaml
+    #raise request.env["omniauth.auth"].to_yaml
     auth = request.env["omniauth.auth"]
-    user = User.where(uid: auth["uid"]).first || User.from_twitter(auth)
+    if session[:user_id] #MOREMORE how to test if a user is signed in here?
+      user = current_user
+      user.uid = auth["uid"].first
+      user.name = auth["screen_name"].first
+    else
+      user = User.where(uid: auth["uid"]).first || User.from_twitter(auth)
+    end
     session[:user_id] = user.id
     flash[:notice] = "You have been logged in through Twitter."
     redirect_back_or root_url

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -17,6 +17,8 @@
           <div class="actions">
             <%= f.submit "Update", class: "btn-lg btn-primary btn-block" %>
           </div>
+          <h4 class="text-center">or</h4>
+          <%= link_to "Add Twitter authorization", "/auth/twitter", class: 'btn-lg btn-primary btn-block text-center' %>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
I hate submitting homework that is so far from complete, but as I've run out of time to finish it I figured I might as well open the PR so at least you'll be aware of where I'm stuck.  I can't seem to get sessions#twitter to recognize auth["screen_name"], although the hash seems to be there when I uncomment the `raise` statement in line 28.  Haven't even begun to work on tests yet.  I hope I get the drift a big better after tomorrow's class.
